### PR TITLE
设置默认发布者; 设置其他GitHub Page项目

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ jobs:
 | username               | string  |          | 'github-actions[bot]' | The publisher's username                                   |
 | email                  | string  |          | '41898282+github-actions[bot]@users.noreply.github.com' | The publisher's email address|
 | if_keep_commit_history | boolean |          | false    | Whether keep commit history                                             |
-| github_page_repository | string  |          |          | When `if_keep_commit_history` is `ture` and the GitHub Page repository is not `<actor_username>.github.io`, you need to set the other GitHub Page repository for get the commit history.|
+| github_page_repository | string  |          |          | When `if_keep_commit_history` is `ture` and the GitHub Page repository (branch) is not `<actor_username>.github.io`, you need to set the other GitHub Page repository (branch) for get the commit history.|
+| github_page_repository_branch | string  |          | 'master' | When `if_keep_commit_history` is `ture` and the GitHub Page repository (branch) is not `<actor_username>.github.io`, you need to set the other GitHub Page repository (branch) for get the commit history.|
 | if_update_files        | boolean |          | false    | Whether update the source file after generate                           |
 | github_token           | secrets |          |          | Token for the repo. Can be passed in using $\{{ secrets.GITHUB_TOKEN }} |
 | branch                 | string  |          | 'master' | The branch of the blog source code                                      |

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ jobs:
       - uses: yrpang/github-actions-hexo@v1.3
         with:
           deploykey: ${{secrets.DEPLOY_KEY}}
-          username: YOUR_USER_NAME
-          email: YOUR_EMAIL_ADDRESS
+          username: PUBLISHER_USER_NAME
+          email: PUBLISHER_EMAIL_ADDRESS
 ```
 
 ### Inputs
@@ -59,8 +59,8 @@ jobs:
 | Name                   | Type    | Required | Default  | Description                                                             |
 | ---------------------- | ------- | -------- | -------- | ----------------------------------------------------------------------- |
 | deploykey              | secrets | **Yes**  |          | The deploy key of your GitHub Page repository                           |
-| username               | string  | **Yes**  |          | Your user name                                                          |
-| email                  | string  | **Yes**  |          | Your email address                                                      |
+| username               | string  |          | 'github-actions[bot]' | The publisher's username                                   |
+| email                  | string  |          | '41898282+github-actions[bot]@users.noreply.github.com' | The publisher's email address|
 | if_keep_commit_history | boolean |          | false    | Whether keep commit history                                             |
 | if_update_files        | boolean |          | false    | Whether update the source file after generate                           |
 | github_token           | secrets |          |          | Token for the repo. Can be passed in using $\{{ secrets.GITHUB_TOKEN }} |

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ jobs:
 | username               | string  |          | 'github-actions[bot]' | The publisher's username                                   |
 | email                  | string  |          | '41898282+github-actions[bot]@users.noreply.github.com' | The publisher's email address|
 | if_keep_commit_history | boolean |          | false    | Whether keep commit history                                             |
+| github_page_repository | string  |          |          | When `if_keep_commit_history` is `ture` and the GitHub Page repository is not `<actor_username>.github.io`, you need to set the other GitHub Page repository for get the commit history.|
 | if_update_files        | boolean |          | false    | Whether update the source file after generate                           |
 | github_token           | secrets |          |          | Token for the repo. Can be passed in using $\{{ secrets.GITHUB_TOKEN }} |
 | branch                 | string  |          | 'master' | The branch of the blog source code                                      |

--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,13 @@ inputs:
     description: 'The develop key of your GitHub Page repository'
     required: true
   username:
-    description: 'Your user name'
-    required: true
+    description: "The publisher's username"
+    required: false
+    default: 'github-actions[bot]'
   email:
-    description: 'Your email address'
-    required: true
+    description: "The publisher's email address"
+    required: false
+    default: '41898282+github-actions[bot]@users.noreply.github.com'
   if_keep_commit_history:
     description: 'Whether keep commit history'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -22,8 +22,13 @@ inputs:
     default: false
   github_page_repository:
     description: >
-      When `if_keep_commit_history` is `ture` and the GitHub Page repository is not `<actor_username>.github.io`, you need to set the other GitHub Page repository for get the commit history.
+      When `if_keep_commit_history` is `ture` and the GitHub Page repository (branch) is not `<actor_username>.github.io`, you need to set the other GitHub Page repository (branch) for get the commit history.
     required: false
+  github_page_repository_branch:
+    description: >
+      When `if_keep_commit_history` is `ture` and the GitHub Page repository (branch) is not `<actor_username>.github.io`, you need to set the other GitHub Page repository (branch) for get the commit history.
+    required: false
+    default: 'master'
   if_update_files:
     description: 'Whether update the source file after generate'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'Whether keep commit history'
     required: false
     default: false
+  github_page_repository:
+    description: >
+      When `if_keep_commit_history` is `ture` and the GitHub Page repository is not `<actor_username>.github.io`, you need to set the other GitHub Page repository for get the commit history.
+    required: false
   if_update_files:
     description: 'Whether update the source file after generate'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e
 
 # setup key
 mkdir -p /root/.ssh/
@@ -18,7 +17,11 @@ npm install
 hexo g
 
 if ${INPUT_IF_KEEP_COMMIT_HISTORY}; then
-    git clone https://github.com/${GITHUB_ACTOR}/${GITHUB_ACTOR}.github.io.git .deploy_git
+    if [ -n "${INPUT_GITHUB_PAGE_REPOSITORY}" ]; then
+        git clone --branch master "https://github.com/${GITHUB_ACTOR}/${INPUT_GITHUB_PAGE_REPOSITORY}.git" .deploy_git
+    else
+        git clone --branch master "https://github.com/${GITHUB_ACTOR}/${GITHUB_ACTOR}.github.io.git" .deploy_git
+    fi
 fi
 
 hexo d

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,9 +18,9 @@ hexo g
 
 if ${INPUT_IF_KEEP_COMMIT_HISTORY}; then
     if [ -n "${INPUT_GITHUB_PAGE_REPOSITORY}" ]; then
-        git clone --branch master "https://github.com/${GITHUB_ACTOR}/${INPUT_GITHUB_PAGE_REPOSITORY}.git" .deploy_git
+        git clone --branch "${INPUT_GITHUB_PAGE_REPOSITORY_BRANCH}" "https://github.com/${GITHUB_ACTOR}/${INPUT_GITHUB_PAGE_REPOSITORY}.git" .deploy_git
     else
-        git clone --branch master "https://github.com/${GITHUB_ACTOR}/${GITHUB_ACTOR}.github.io.git" .deploy_git
+        git clone --branch "${INPUT_GITHUB_PAGE_REPOSITORY_BRANCH}" "https://github.com/${GITHUB_ACTOR}/${GITHUB_ACTOR}.github.io.git" .deploy_git
     fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ npm install
 hexo g
 
 if ${INPUT_IF_KEEP_COMMIT_HISTORY}; then
-    git clone https://github.com/${INPUT_USERNAME}/${INPUT_USERNAME}.github.io.git .deploy_git
+    git clone https://github.com/${GITHUB_ACTOR}/${GITHUB_ACTOR}.github.io.git .deploy_git
 fi
 
 hexo d


### PR DESCRIPTION
- 设置默认发布者为`github-actions[bot]`
- 可设置其他GitHub Page项目而非`<actor_username>.github.io`

示例:
https://github.com/maboloshi/Blog/actions/runs/308501344/workflow
```yml
name: Hexo CICD

on:
  workflow_dispatch:
  push:
      branches:
      - hexo
      paths:
      - 'source/**'
      - 'themes/**'
      - '_config.yml'

jobs:
  build:
    runs-on: ubuntu-latest
    if: "!contains(github.event.head_commit.message, '[ci skip]')"
    steps:
      - name: Checkout
        uses: actions/checkout@v2
        with:
          ref: hexo
          submodules: true
      - name: Cache node modules
        uses: actions/cache@v2
        with:
          path: node_modules
          key: ${{runner.OS}}-node-${{hashFiles('**/package-lock.json')}}
          restore-keys: |
            ${{ runner.os }}-node-
      - uses: maboloshi/github-actions-hexo@dev
        with:
          deploykey: ${{secrets.DEPLOY_KEY}}
          if_keep_commit_history: true
          github_page_repository: Blog
```
<img width="627" alt="截屏2020-10-15 下午7 59 33" src="https://user-images.githubusercontent.com/7850715/96120414-0ceb0b80-0f21-11eb-8b4d-37d763349f35.png">
